### PR TITLE
update support for Redux-Logger 3

### DIFF
--- a/src/message-board.js
+++ b/src/message-board.js
@@ -1,6 +1,6 @@
 import { createStore, combineReducers, applyMiddleware } from 'redux'
 import { get } from './http';
-import logger from 'redux-logger';
+import { createLogger } from 'redux-logger'
 
 export const ONLINE = `ONLINE`;
 export const AWAY = `AWAY`;
@@ -99,7 +99,7 @@ const combinedReducer = combineReducers({
 
 const store = createStore(
     combinedReducer,
-    applyMiddleware(logger())
+    applyMiddleware(createLogger())
 );
 
 const render = ()=>{
@@ -107,7 +107,7 @@ const render = ()=>{
     document.getElementById("messages").innerHTML = messages
         .sort((a,b)=>b.date - a.date)
         .map(message=>(`
-    <div> 
+    <div>
         ${message.postedBy} : ${message.content}
     </div>`
     )).join("");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     output: {
         path: path.resolve(__dirname, "public"),
-        publicPath: "/public/assets/",
+        publicPath: "/assets/",
         filename: "[name].bundle.js"
     },
     devServer: { inline: true },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     output: {
         path: path.resolve(__dirname, "public"),
-        publicPath: "/assets/",
+        publicPath: "/public/assets/",
         filename: "[name].bundle.js"
     },
     devServer: { inline: true },


### PR DESCRIPTION
First of all, I'm running the code on a Mac and /public/assets/*.js files can't be found when I run `webpack-dev-server`. So I modified webpack.config.js to fix it.

I'm using version 3 of Redux-Logger, so `import logger from 'redux-logger';` will lead to an error saying we should use `import { createLogger } from 'redux-logger'` instead. So I also made some changes accordingly. 

<img width="679" alt="screen shot 2017-04-18 at 6 49 05 pm" src="https://cloud.githubusercontent.com/assets/13964463/25127408/439c6aa4-2468-11e7-9bc6-28b5f6f8e080.png">

Overall all the code are the same. I just made some slight changes to make it work.

 